### PR TITLE
chore: remove deprecated action

### DIFF
--- a/recipes/ci-cd/github-actions/workflows/rust/index.md
+++ b/recipes/ci-cd/github-actions/workflows/rust/index.md
@@ -21,7 +21,7 @@ This uses Rust that is already set up in the enviroment.
     on:
       push:
         branches: [ main ]
-        
+
       pull_request:
         branches: [ main ]
 
@@ -33,49 +33,12 @@ This uses Rust that is already set up in the enviroment.
         runs-on: ubuntu-latest
 
         steps:
-        - name: Checkout 🛎️ 
-          uses: actions/checkout@v2
-        
-        - name: Build 🏗️ 
+        - name: Checkout 🛎️
+          uses: actions/checkout@v4
+
+        - name: Build 🏗️
           run: cargo build --verbose
-          
+
         - name: Test 🚨
           run: cargo test --verbose
     ```
- 
-
-### Simple Infra
-
-This uses an Action is maintained by the Rust team.
-
-The [simple-ci](https://github.com/rust-lang/simpleinfra/tree/master/github-actions/simple-ci) action, from the `rust-lang/simpleinfr` repo.
-
-> This builds, tests, and checks the formatting of your project.
-
-- `main.yml`
-    ```yaml 
-    name: Rust CI
-
-    on:
-      push:
-        branches: [main]
-        paths-ignore:
-          - "docs/**"
-
-      pull_request:
-        branches: [main]
-        paths-ignore:
-          - "docs/**"
-
-    jobs:
-      build:
-        runs-on: ubuntu-latest
-
-        steps:
-          - uses: actions/checkout@v2
-
-          - name: Set up Rust 🦀
-            uses: rust-lang/simpleinfra/github-actions/simple-ci@master
-            with:
-              check_fmt: true
-```


### PR DESCRIPTION
Hi, I'm Marco from the Rust Infra team 👋

As described in https://github.com/rust-lang/simpleinfra/issues/445 we want to delete the `simple-ci` GitHub action.

Let me know if you have any questions 🙏

